### PR TITLE
updating after first run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@ This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next
 
 ## Getting Started
 
-First, run the development server:
+First, install the dependencies:
+
+```bash
+npm install
+```
+
+Secound, run the development server:
 
 ```bash
 npm run dev

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
-    "start": "next start",
-    "lint": "next lint"
+    "dev": "NEXT_TELEMETRY_DEBUG=1 next dev",
+    "build": "NEXT_TELEMETRY_DEBUG=1 next build",
+    "start": "NEXT_TELEMETRY_DEBUG=1 next start",
+    "lint": "NEXT_TELEMETRY_DEBUG=1 next lint"
   },
   "dependencies": {
     "@next/font": "13.1.1",


### PR DESCRIPTION
the readme to install dependencies, 
and preventing from tracing to https://nextjs.org 

althought https://github.com/vercel/next.js/discussions/43947 might still cause traces